### PR TITLE
Use self-hosted runner in gha

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -66,7 +66,8 @@ jobs:
             os: ubuntu-20.04
             install: libc++-12-dev libc++abi-12-dev
 
-    runs-on: ${{matrix.os}}
+    # runs-on: ${{matrix.os}}
+    runs-on: [self-hosted, linux, x64]
 
     steps:
       - uses: actions/checkout@v2
@@ -106,7 +107,8 @@ jobs:
 
       - name: Run benchmarks
         run: |
-          ./${{matrix.outputfile}}
+          # ./${{matrix.outputfile}}
+          sudo cset shield --exec -- nice -n -20 sudo -u gha ./${{matrix.outputfile}}
 
   windows:
     strategy:


### PR DESCRIPTION
The self-hosted runners are executing jobs in series, not in parallel. So, it takes time. A way to speed up the overall CI would be to reduce the number of jobs, reduce the size of the matrix.  

The command which runs the benchmarks uses "cset" and "nice". You could run the benchmarks without those enhancements however the results would fluctuate more. 
- cset isolates the task on a protected cpu where other processes are not running.
- nice gives it top priority.
